### PR TITLE
Add support for expired password on login

### DIFF
--- a/freeipa/client.go
+++ b/freeipa/client.go
@@ -109,7 +109,17 @@ func (c *Client) login() error {
 	if e != nil {
 		return e
 	}
+
 	if res.StatusCode != http.StatusOK {
+		if res.StatusCode == http.StatusUnauthorized {
+			if rejectionReason := res.Header.Get("X-Ipa-Rejection-Reason"); rejectionReason == "password-expired" {
+				return &Error{
+					Message: rejectionReason,
+					Name:    rejectionReason,
+					Code:    PasswordExpiredCode,
+				}
+			}
+		}
 		return fmt.Errorf("unexpected http status code: %v", res.StatusCode)
 	}
 	return nil

--- a/freeipa/client.go
+++ b/freeipa/client.go
@@ -73,7 +73,7 @@ func Connect(host string, tspt *http.Transport, user, pw string) (*Client, error
 		pw:   pw,
 	}
 	if e := c.login(); e != nil {
-		return nil, fmt.Errorf("initial login falied: %v", e)
+		return nil, fmt.Errorf("initial login failed: %v", e)
 	}
 	return c, nil
 }


### PR DESCRIPTION
Currently, when a user try to log in using _username_ / _password_ with an expired password, there is no way to properly detect this scenario.

This P.R modify the `login()` method to detect that scenario and raises a `freeipa.Error` with proper code set.