### PR TITLE
Always expose Dn when objects return it

### DIFF
--- a/gen/main.go
+++ b/gen/main.go
@@ -163,6 +163,22 @@ func loadSchema() (*Schema, error) {
 				}
 			}
 
+			// Add Dn to all types
+			hasDn := false
+			for _, p := range c.Params {
+				if p.Name == "dn" {
+					hasDn = true
+					break
+				}
+			}
+			if !hasDn {
+				dn := Param{
+					Name: "dn",
+					Type: "string",
+				}
+				c.Params = append(c.Params, &dn)
+			}
+
 			classes = append(classes, c)
 		}
 	}


### PR DESCRIPTION
Several objects (all?) contain a standard "dn" field which identifies
them uniquely in the API but is not listed in the json schema.