### PR TITLE
Implement Kerberos login

### DIFF
--- a/freeipa/kerberos.go
+++ b/freeipa/kerberos.go
@@ -1,0 +1,10 @@
+package freeipa
+
+import "io"
+
+type KerberosConnectOptions struct {
+	Krb5ConfigReader io.Reader
+	KeytabReader     io.Reader
+	Username         string
+	Realm            string
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/tehwalris/go-freeipa
+
+go 1.15
+
+require (
+	github.com/jcmturner/gokrb5/v8 v8.4.1
+	github.com/pkg/errors v0.9.1
+)


### PR DESCRIPTION
Add support for logging in using Kerberos Keytab ( see #5 )

This is a first implementation to start the discussion.

I've added an example of how to use this implementation in the `freeipa/example_test.go` file.